### PR TITLE
Unify GhostNet scrollable layout and hero styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "yargs": "^17.2.1"
       },
       "devDependencies": {
+        "@next/swc-linux-x64-gnu": "^12.3.4",
         "@testing-library/jest-dom": "^6.1.3",
         "@testing-library/react": "^12.1.5",
         "babel-jest": "^29.7.0",
@@ -1795,7 +1796,6 @@
       ],
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@next/swc-linux-x64-gnu": "^12.3.4",
     "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/react": "^12.1.5",
-    
     "babel-jest": "^29.7.0",
     "changeexe": "^1.0.2",
     "cross-env": "^7.0.3",
@@ -47,8 +47,8 @@
     "makensis": "^1.1.1",
     "nexe": "^4.0.0-beta.19",
     "next": "^12.1.5",
-    "playwright": "^1.45.0",
     "nodemon": "^2.0.15",
+    "playwright": "^1.45.0",
     "puppeteer": "^14.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/client/components/panel.js
+++ b/src/client/components/panel.js
@@ -1,14 +1,25 @@
 import PanelNavigation from 'components/panel-navigation'
 
 export default function Panel ({ children, layout = 'full-width', scrollable = false, navigation, search, exit, style = {}, className = '' }) {
+  const hasNavigation = Array.isArray(navigation) && navigation.length > 0
+  const panelClassName = [
+    `layout__${layout}`,
+    'layout__panel',
+    scrollable ? 'layout__panel--scrollable scrollable' : '',
+    hasNavigation ? 'layout__panel--secondary-navigation' : '',
+    className
+  ].filter(Boolean).join(' ')
+
   return (
-    <div
-      className={`layout__${layout} ${scrollable ? 'scrollable' : ''} ${(navigation && navigation.length > 0) ? 'layout__panel--secondary-navigation' : ''} ${className}`}
-      style={{ ...style }}
-    >
-      {navigation && navigation.length > 0 &&
-        <PanelNavigation items={navigation} search={search} exit={exit} />}
-      {children}
+    <div className={panelClassName} style={{ ...style }}>
+      {hasNavigation && <PanelNavigation items={navigation} search={search} exit={exit} />}
+      {scrollable ? (
+        <div className='layout__panel-scroll scrollable'>
+          {children}
+        </div>
+      ) : (
+        children
+      )}
     </div>
   )
 }

--- a/src/client/css/pages/ghostnet.css
+++ b/src/client/css/pages/ghostnet.css
@@ -15,6 +15,12 @@
   --ghostnet-color-success: #29f3c3;
   /* Warning and error feedback across the GhostNet UI */
   --ghostnet-color-warning: #ff5fc1;
+  /* Scrollbar track colour for the workspace viewport */
+  --ghostnet-color-scroll-track: color-mix(in srgb, var(--ghostnet-color-background) 82%, transparent);
+  /* Scrollbar thumb colour that keeps the square silhouette readable */
+  --ghostnet-color-scroll-thumb: color-mix(in srgb, var(--ghostnet-color-primary) 62%, transparent);
+  /* Outline used to crispen the scrollbar thumb edges */
+  --ghostnet-color-scroll-thumb-border: color-mix(in srgb, var(--ghostnet-color-primary-dark) 46%, transparent);
 }
 
 .ghostnet-spinner {

--- a/src/client/css/ui/layout.css
+++ b/src/client/css/ui/layout.css
@@ -48,6 +48,27 @@
   height: 100%;
 }
 
+.layout__panel {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.layout__panel--scrollable {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.layout__panel-scroll {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  scrollbar-gutter: stable both-edges;
+  overscroll-behavior: contain;
+}
+
 .layout__left-half,
 .layout__right-half {
   position: relative;

--- a/src/client/pages/ghostnet.js
+++ b/src/client/pages/ghostnet.js
@@ -4462,9 +4462,21 @@ export default function GhostnetPage() {
 
   return (
     <Layout connected={connected} active={socketActive} ready={ready} loader={false}>
-      <Panel layout='full-width' navigation={navigationItems} search={false}>
+      <Panel
+        layout='full-width'
+        scrollable
+        navigation={navigationItems}
+        search={false}
+        className={styles.ghostnetPanel}
+      >
         <div className={ghostnetClassName}>
           <div className={styles.hero}>
+            <div className={styles.heroHeader}>
+              <h1 className={styles.heroTitle}>GhostNet Operations</h1>
+              <p className={styles.heroSubtitle}>
+                Synthesise trade intelligence, mission alerts, and refinery telemetry in one continuous sweep.
+              </p>
+            </div>
             <aside className={styles.heroStatus} role='complementary' aria-label='Signal Brief'>
               <dl className={styles.heroStatusList}>
                 <div className={styles.heroStatusItem}>

--- a/src/client/pages/ghostnet.module.css
+++ b/src/client/pages/ghostnet.module.css
@@ -21,6 +21,9 @@
   --ghostnet-accent: var(--ghostnet-color-primary-light);
   --ghostnet-highlight: color-mix(in srgb, var(--ghostnet-color-primary-light) 18%, transparent);
   --ghostnet-highlight-strong: color-mix(in srgb, var(--ghostnet-color-primary) 25%, transparent);
+  --ghostnet-scrollbar-track: var(--ghostnet-color-scroll-track);
+  --ghostnet-scrollbar-thumb: var(--ghostnet-color-scroll-thumb);
+  --ghostnet-scrollbar-thumb-border: var(--ghostnet-color-scroll-thumb-border);
   --ghostnet-table-header: linear-gradient(
     180deg,
     color-mix(in srgb, var(--ghostnet-color-primary) 82%, transparent) 0%,
@@ -52,6 +55,36 @@
   inset: 0;
   background: linear-gradient(180deg, transparent 0%, color-mix(in srgb, var(--ghostnet-color-background) 90%, transparent) 100%);
   pointer-events: none;
+}
+
+.ghostnetPanel :global(.layout__panel-scroll) {
+  padding: 0;
+  background: var(--ghostnet-bg);
+  scrollbar-color: var(--ghostnet-scrollbar-thumb) var(--ghostnet-scrollbar-track);
+  scrollbar-width: thin;
+}
+
+.ghostnetPanel :global(.layout__panel-scroll::-webkit-scrollbar) {
+  width: 14px;
+  background-color: var(--ghostnet-scrollbar-track);
+}
+
+
+.ghostnetPanel :global(.layout__panel-scroll::-webkit-scrollbar-track) {
+  background: var(--ghostnet-scrollbar-track);
+  border: 1px solid color-mix(in srgb, var(--ghostnet-scrollbar-thumb-border) 40%, transparent);
+  border-radius: 0;
+}
+
+.ghostnetPanel :global(.layout__panel-scroll::-webkit-scrollbar-thumb) {
+  background: var(--ghostnet-scrollbar-thumb);
+  border: 1px solid var(--ghostnet-scrollbar-thumb-border);
+  border-radius: 0;
+  box-shadow: 0 0 1.5rem color-mix(in srgb, var(--ghostnet-color-primary) 28%, transparent);
+}
+
+.ghostnetPanel :global(.layout__panel-scroll::-webkit-scrollbar-thumb:hover) {
+  background: color-mix(in srgb, var(--ghostnet-scrollbar-thumb) 70%, var(--ghostnet-color-primary-light));
 }
 
 .arrival {
@@ -934,6 +967,8 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
 .opportunityIntro {
   display: grid;
   gap: 0.75rem;
+  max-width: 46rem;
+  padding-bottom: 1.5rem;
 }
 
 .opportunityName {
@@ -1926,16 +1961,17 @@ button.terminalToggle:active:not([disabled]):not(.button--active) {
 }
 
 .placeholder {
-  margin: 2.5rem auto;
-  max-width: 36rem;
-  padding: 3rem 2.5rem;
+  margin: 3rem auto;
+  max-width: 40rem;
+  padding: 2.75rem 3rem;
   text-align: center;
-  color: var(--ghostnet-muted);
-  font-size: 1.35rem;
-  border-radius: 1.5rem;
-  border: 1px solid color-mix(in srgb, var(--ghostnet-color-primary) 28%, transparent);
-  background: linear-gradient(160deg, color-mix(in srgb, var(--ghostnet-color-primary) 18%, transparent), color-mix(in srgb, var(--ghostnet-color-background) 82%, transparent));
-  box-shadow: 0 1.85rem 4rem color-mix(in srgb, var(--ghostnet-color-background) 78%, transparent);
+  color: var(--ghostnet-text-soft);
+  font-size: 1.1rem;
+  line-height: 1.65;
+  border-radius: 1rem;
+  border: 1px solid var(--ghostnet-border-regular);
+  background: color-mix(in srgb, var(--ghostnet-color-background) 88%, transparent);
+  box-shadow: 0 1.35rem 3.2rem color-mix(in srgb, var(--ghostnet-shadow) 58%, transparent);
 }
 
 .ghostnet :global(.ghostnet-surface) {

--- a/src/client/pages/ghostnet/engineering.js
+++ b/src/client/pages/ghostnet/engineering.js
@@ -106,7 +106,7 @@ export default function GhostnetEngineeringOpportunitiesPage () {
 
   return (
     <Layout connected={connected} active={active} ready={ready} loader={!componentReady}>
-      <Panel layout='full-width' scrollable navigation={navigationItems}>
+      <Panel layout='full-width' scrollable navigation={navigationItems} className={styles.ghostnetPanel}>
         <div className={styles.ghostnet}>
           <div className={styles.hero}>
             <div className={styles.heroHeader}>
@@ -135,20 +135,18 @@ export default function GhostnetEngineeringOpportunitiesPage () {
 
           <div className={styles.shell}>
             <div className={styles.sectionGroup}>
-              <div className={`${styles.sectionFrame} ${styles.sectionPadding}`}>
-                <div className={styles.opportunityIntro}>
-                  <p className={styles.sectionHint}>
-                    Track the optimal workshop to visit for each upgrade. We surface only the blueprints you can afford this
-                    moment, factoring in material trades and recent crafts.
-                  </p>
-                  <p className={styles.sectionHint}>
-                    Material tallies update as the Ghost Net ingests new journal entries, so keep the console running while you
-                    gather resources.
-                  </p>
-                </div>
-              </div>
+              <section className={styles.opportunityIntro}>
+                <p className={styles.sectionHint}>
+                  Track the optimal workshop to visit for each upgrade. We surface only the blueprints you can afford this
+                  moment, factoring in material trades and recent crafts.
+                </p>
+                <p className={styles.sectionHint}>
+                  Material tallies update as the Ghost Net ingests new journal entries, so keep the console running while you
+                  gather resources.
+                </p>
+              </section>
 
-              <div className={styles.tableSection}>
+              <section className={styles.tableSection}>
                 <div className={styles.tableSectionHeader}>
                   <div>
                     <h2 className={styles.tableSectionTitle}>Ready for fabrication</h2>
@@ -263,7 +261,7 @@ export default function GhostnetEngineeringOpportunitiesPage () {
                     </table>
                   </div>
                 )}
-              </div>
+              </section>
             </div>
           </div>
         </div>

--- a/src/client/pages/ghostnet/engineering/[symbol].js
+++ b/src/client/pages/ghostnet/engineering/[symbol].js
@@ -183,7 +183,7 @@ export default function EngineeringBlueprintDetailPage () {
 
   return (
     <Layout connected={connected} active={active} ready={ready} loader={!componentReady}>
-      <Panel layout='full-width' scrollable navigation={navigationItems}>
+      <Panel layout='full-width' scrollable navigation={navigationItems} className={styles.ghostnetPanel}>
         <div className={styles.ghostnet}>
           <div className={styles.engineeringDetailContainer}>
             <div className={styles.engineeringDetailBackRow}>

--- a/src/client/pages/ghostnet/outfitting.js
+++ b/src/client/pages/ghostnet/outfitting.js
@@ -1,6 +1,6 @@
+import { useEffect } from 'react'
 import Layout from 'components/layout'
 import Panel from 'components/panel'
-import PanelNavigation from 'components/panel-navigation'
 import styles from '../ghostnet.module.css'
 
 const navItems = [
@@ -19,12 +19,28 @@ const navItems = [
 ]
 
 export default function GhostnetOutfittingPage () {
+  useEffect(() => {
+    if (typeof document === 'undefined' || !document.body) return undefined
+    document.body.classList.add('ghostnet-theme')
+    return () => document.body.classList.remove('ghostnet-theme')
+  }, [])
+
   return (
     <Layout>
-      <PanelNavigation items={navItems} />
-      <Panel layout='full-width' scrollable>
-        <div className={styles.placeholder}>
-          Outfitting tools coming soon
+      <Panel layout='full-width' scrollable navigation={navItems} className={styles.ghostnetPanel}>
+        <div className={styles.ghostnet}>
+          <div className={styles.hero}>
+            <div className={styles.heroHeader}>
+              <h1 className={styles.heroTitle}>Outfitting Tools</h1>
+              <p className={styles.heroSubtitle}>
+                Ship build intelligence is in fabrication. Stay tuned for modular loadouts and curated upgrade paths.
+              </p>
+            </div>
+          </div>
+
+          <div className={styles.shell}>
+            <div className={styles.placeholder}>Outfitting consoles are coming online soon.</div>
+          </div>
         </div>
       </Panel>
     </Layout>

--- a/src/client/pages/ghostnet/search.js
+++ b/src/client/pages/ghostnet/search.js
@@ -1,6 +1,6 @@
+import { useEffect } from 'react'
 import Layout from 'components/layout'
 import Panel from 'components/panel'
-import PanelNavigation from 'components/panel-navigation'
 import styles from '../ghostnet.module.css'
 
 const navItems = [
@@ -19,12 +19,28 @@ const navItems = [
 ]
 
 export default function GhostnetSearchPage() {
+  useEffect(() => {
+    if (typeof document === 'undefined' || !document.body) return undefined
+    document.body.classList.add('ghostnet-theme')
+    return () => document.body.classList.remove('ghostnet-theme')
+  }, [])
+
   return (
     <Layout>
-      <PanelNavigation items={navItems} />
-      <Panel layout='full-width' scrollable>
-        <div className={styles.placeholder}>
-          General Search Disabled
+      <Panel layout='full-width' scrollable navigation={navItems} className={styles.ghostnetPanel}>
+        <div className={styles.ghostnet}>
+          <div className={styles.hero}>
+            <div className={styles.heroHeader}>
+              <h1 className={styles.heroTitle}>Signal Search</h1>
+              <p className={styles.heroSubtitle}>
+                Global lookup is recalibrating to the new assimilation backbone. Search returns soon.
+              </p>
+            </div>
+          </div>
+
+          <div className={styles.shell}>
+            <div className={styles.placeholder}>General search is temporarily disabled.</div>
+          </div>
         </div>
       </Panel>
     </Layout>


### PR DESCRIPTION
## Summary
- add the linux SWC binary as a dev dependency so GhostNet builds run without native compilation
- refactor the shared `Panel` container to expose a dedicated scroll region with square GhostNet scrollbars
- align GhostNet page heroes, table shells, and placeholder messaging across the main, engineering, search, and outfitting views

## Testing
- npm test -- --runInBand --config jest.config.js
- CI=1 npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68e092a868cc83239f8d398b07ccd62d